### PR TITLE
Add monthly refresh background service, API retry/retry-backoff and transactional truncate

### DIFF
--- a/Infrastructure/Repositories/CityPrayerTimesRepository.cs
+++ b/Infrastructure/Repositories/CityPrayerTimesRepository.cs
@@ -80,12 +80,12 @@ namespace Infrastructure.Repositories
         {
             try
             {
-                await _context.Database.ExecuteSqlRawAsync("SET FOREIGN_KEY_CHECKS = 0;");
+                await using var transaction = await _context.Database.BeginTransactionAsync();
 
                 await _context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE DailyPrayerTimes;");
                 await _context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE CityPrayerTimes;");
 
-                await _context.Database.ExecuteSqlRawAsync("SET FOREIGN_KEY_CHECKS = 1;");
+                await transaction.CommitAsync();
             }
             catch (Exception ex)
             {

--- a/Infrastructure/Services/PrayerTimeService.cs
+++ b/Infrastructure/Services/PrayerTimeService.cs
@@ -14,6 +14,8 @@ namespace Infrastructure.Services
         private readonly ILogger<PrayerTimeService> _logger;
         private readonly HttpClient _httpClient;
         private const string URL_SUFFIX = "&tz=Europe%2FCopenhagen&fa=-18.0&ea=-17.0&fea=0&rsa=0";
+        private const int MaxApiRetries = 5;
+        private static readonly TimeSpan DefaultRetryDelay = TimeSpan.FromSeconds(30);
         private readonly Dictionary<string, (string Fajr, string Isha)> _predefinedTimes = new()
         {
             { "cph", ("01:21:00", "00:38:00") },
@@ -98,21 +100,44 @@ namespace Infrastructure.Services
 
         private async Task<MuwaqqitResponse> GetApiPrayerData(string url)
         {
-            HttpResponseMessage response = await _httpClient.GetAsync(url);
-
-            _logger.LogInformation("Received HTTP status {StatusCode} for URL {Url}", response.StatusCode, url);
-
-            if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+            for (var attempt = 1; attempt <= MaxApiRetries; attempt++)
             {
-                var retryAfter = response.Headers.RetryAfter?.Delta?.TotalSeconds ?? 30;
-                _logger.LogWarning("Rate limit hit, retrying after {RetryAfterSeconds} seconds", retryAfter);
-                await Task.Delay((int)retryAfter * 1000);
-                return await GetApiPrayerData(url);
+                HttpResponseMessage response = await _httpClient.GetAsync(url);
+
+                _logger.LogInformation("Received HTTP status {StatusCode} for URL {Url} on attempt {Attempt}/{MaxAttempts}", response.StatusCode, url, attempt, MaxApiRetries);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var responseContent = await response.Content.ReadAsStringAsync();
+                    return JsonConvert.DeserializeObject<MuwaqqitResponse>(responseContent);
+                }
+
+                if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                {
+                    var retryDelay = response.Headers.RetryAfter?.Delta ?? DefaultRetryDelay;
+
+                    if (attempt == MaxApiRetries)
+                    {
+                        break;
+                    }
+
+                    _logger.LogWarning("Rate limit hit. Retrying in {RetryDelaySeconds} seconds (attempt {Attempt}/{MaxAttempts}).", retryDelay.TotalSeconds, attempt, MaxApiRetries);
+                    await Task.Delay(retryDelay);
+                    continue;
+                }
+
+                if ((int)response.StatusCode >= 500 && attempt < MaxApiRetries)
+                {
+                    var retryDelay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+                    _logger.LogWarning("Transient server error {StatusCode}. Retrying in {RetryDelaySeconds} seconds (attempt {Attempt}/{MaxAttempts}).", response.StatusCode, retryDelay.TotalSeconds, attempt, MaxApiRetries);
+                    await Task.Delay(retryDelay);
+                    continue;
+                }
+
+                response.EnsureSuccessStatusCode();
             }
 
-            response.EnsureSuccessStatusCode();
-            var responseContent = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<MuwaqqitResponse>(responseContent);
+            throw new HttpRequestException($"Failed to fetch prayer data from API after {MaxApiRetries} attempts.");
         }
 
         private async Task<CityPrayerTimes> ProcessAndStoreApiData(CityPrayerTimes cityPrayerTimes, MuwaqqitResponse muwaqqitResponse, string city)

--- a/Web/Services/MonthlyPrayerTimesRefreshService.cs
+++ b/Web/Services/MonthlyPrayerTimesRefreshService.cs
@@ -1,0 +1,88 @@
+using Application.Interfaces;
+using Domain.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Runtime.InteropServices;
+
+namespace Web.Services
+{
+    public class MonthlyPrayerTimesRefreshService : BackgroundService
+    {
+        private static readonly string[] SupportedCities = ["cph", "odense", "aarhus", "aalborg"];
+
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<MonthlyPrayerTimesRefreshService> _logger;
+
+        public MonthlyPrayerTimesRefreshService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<MonthlyPrayerTimesRefreshService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var denmarkTimeZone = GetDenmarkTimeZone();
+
+            await RefreshIfNeededAsync(denmarkTimeZone, stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var delay = GetDelayUntilNextMidnight(denmarkTimeZone);
+                _logger.LogInformation("Monthly refresh worker sleeping for {Delay} until next Denmark midnight.", delay);
+                await Task.Delay(delay, stoppingToken);
+                await RefreshIfNeededAsync(denmarkTimeZone, stoppingToken);
+            }
+        }
+
+        private async Task RefreshIfNeededAsync(TimeZoneInfo denmarkTimeZone, CancellationToken cancellationToken)
+        {
+            var nowInDenmark = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, denmarkTimeZone);
+            var firstOfMonth = new DateTime(nowInDenmark.Year, nowInDenmark.Month, 1);
+
+            using var scope = _scopeFactory.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<ICityPrayerTimesRepository>();
+            var prayerTimeService = scope.ServiceProvider.GetRequiredService<IPrayerTimeService>();
+
+            var allRows = await repository.GetAllAsync();
+            var hasCurrentMonthData = allRows
+                .SelectMany(c => c.PrayerTimes)
+                .Any(p => p.Date.Year == firstOfMonth.Year && p.Date.Month == firstOfMonth.Month);
+
+            if (hasCurrentMonthData)
+            {
+                _logger.LogInformation("Monthly refresh skipped. Data for {Month}/{Year} already exists.", firstOfMonth.Month, firstOfMonth.Year);
+                return;
+            }
+
+            _logger.LogInformation("Refreshing prayer calendar data for {Month}/{Year}.", firstOfMonth.Month, firstOfMonth.Year);
+            await repository.TruncateTablesAsync();
+
+            foreach (var city in SupportedCities)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await prayerTimeService.FetchAndCachePrayerTimesAsync(city);
+            }
+
+            _logger.LogInformation("Monthly prayer calendar refresh complete for {Month}/{Year}.", firstOfMonth.Month, firstOfMonth.Year);
+        }
+
+        private static TimeSpan GetDelayUntilNextMidnight(TimeZoneInfo denmarkTimeZone)
+        {
+            var nowInDenmark = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, denmarkTimeZone);
+            var nextMidnightInDenmark = nowInDenmark.Date.AddDays(1);
+            return nextMidnightInDenmark - nowInDenmark;
+        }
+
+        private static TimeZoneInfo GetDenmarkTimeZone()
+        {
+            var timeZoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? "Romance Standard Time"
+                : "Europe/Copenhagen";
+
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+    }
+}

--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using Web.Mapping;
+using Web.Services;
 
 namespace Web
 {
@@ -51,6 +52,7 @@ namespace Web
             services.AddHttpClient<IPrayerTimeService, PrayerTimeService>();
             services.AddAutoMapper(typeof(MappingProfile));
             services.AddAutoMapper(typeof(DTOToviewModelMappingProfile));
+            services.AddHostedService<MonthlyPrayerTimesRefreshService>();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)


### PR DESCRIPTION
### Motivation

- Ensure monthly prayer calendar data is refreshed automatically at Denmark midnight and avoid partial truncation issues when clearing tables.
- Improve robustness of external API calls by handling rate limits and transient server errors with retries and backoff.
- Replace direct toggling of foreign key checks with a proper transactional truncate to be safer and more portable.

### Description

- Added `MonthlyPrayerTimesRefreshService` background service that runs daily at Denmark midnight, checks for current-month data, truncates tables, and refreshes prayer times for supported cities (`cph`, `odense`, `aarhus`, `aalborg`).
- Registered the hosted service in `Startup.cs` with `services.AddHostedService<MonthlyPrayerTimesRefreshService>();`.
- Reworked `CityPrayerTimesRepository.TruncateTablesAsync` to use an EF Core transaction via `BeginTransactionAsync()` and `CommitAsync()` instead of toggling `FOREIGN_KEY_CHECKS` SQL flags.
- Enhanced `PrayerTimeService.GetApiPrayerData` to add retry logic with `MaxApiRetries`, handling `429 TooManyRequests` using `Retry-After`, applying exponential backoff for 5xx responses, richer logging, and throwing an `HttpRequestException` after exhausting retries.

### Testing

- Ran `dotnet build` to verify the solution compiles successfully and the new background service registers without errors.
- Ran existing automated tests with `dotnet test` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25bcd02c88328bccc51e92fb80529)