### PR TITLE
Add API retry/backoff, monthly refresh worker, diagnostics endpoint, and transactional table truncate

### DIFF
--- a/Infrastructure/Repositories/CityPrayerTimesRepository.cs
+++ b/Infrastructure/Repositories/CityPrayerTimesRepository.cs
@@ -80,12 +80,12 @@ namespace Infrastructure.Repositories
         {
             try
             {
-                await _context.Database.ExecuteSqlRawAsync("SET FOREIGN_KEY_CHECKS = 0;");
+                await using var transaction = await _context.Database.BeginTransactionAsync();
 
-                await _context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE DailyPrayerTimes;");
-                await _context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE CityPrayerTimes;");
+                await _context.Database.ExecuteSqlRawAsync("DELETE FROM DailyPrayerTimes;");
+                await _context.Database.ExecuteSqlRawAsync("DELETE FROM CityPrayerTimes;");
 
-                await _context.Database.ExecuteSqlRawAsync("SET FOREIGN_KEY_CHECKS = 1;");
+                await transaction.CommitAsync();
             }
             catch (Exception ex)
             {

--- a/Infrastructure/Services/PrayerTimeService.cs
+++ b/Infrastructure/Services/PrayerTimeService.cs
@@ -14,6 +14,8 @@ namespace Infrastructure.Services
         private readonly ILogger<PrayerTimeService> _logger;
         private readonly HttpClient _httpClient;
         private const string URL_SUFFIX = "&tz=Europe%2FCopenhagen&fa=-18.0&ea=-17.0&fea=0&rsa=0";
+        private const int MaxApiRetries = 5;
+        private static readonly TimeSpan DefaultRetryDelay = TimeSpan.FromSeconds(30);
         private readonly Dictionary<string, (string Fajr, string Isha)> _predefinedTimes = new()
         {
             { "cph", ("01:21:00", "00:38:00") },
@@ -98,21 +100,63 @@ namespace Infrastructure.Services
 
         private async Task<MuwaqqitResponse> GetApiPrayerData(string url)
         {
-            HttpResponseMessage response = await _httpClient.GetAsync(url);
-
-            _logger.LogInformation("Received HTTP status {StatusCode} for URL {Url}", response.StatusCode, url);
-
-            if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+            for (var attempt = 1; attempt <= MaxApiRetries; attempt++)
             {
-                var retryAfter = response.Headers.RetryAfter?.Delta?.TotalSeconds ?? 30;
-                _logger.LogWarning("Rate limit hit, retrying after {RetryAfterSeconds} seconds", retryAfter);
-                await Task.Delay((int)retryAfter * 1000);
-                return await GetApiPrayerData(url);
+                HttpResponseMessage response = await _httpClient.GetAsync(url);
+
+                _logger.LogInformation("Received HTTP status {StatusCode} for URL {Url} on attempt {Attempt}/{MaxAttempts}", response.StatusCode, url, attempt, MaxApiRetries);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var responseContent = await response.Content.ReadAsStringAsync();
+
+                    if (int.TryParse(responseContent.Trim(), out var numericResponse) && numericResponse == 429)
+                    {
+                        if (attempt == MaxApiRetries)
+                        {
+                            break;
+                        }
+
+                        _logger.LogWarning("Muwaqqit returned body-only rate limit marker (429). Retrying in {RetryDelaySeconds} seconds (attempt {Attempt}/{MaxAttempts}).", DefaultRetryDelay.TotalSeconds, attempt, MaxApiRetries);
+                        await Task.Delay(DefaultRetryDelay);
+                        continue;
+                    }
+
+                    var deserialized = JsonConvert.DeserializeObject<MuwaqqitResponse>(responseContent);
+                    if (deserialized == null)
+                    {
+                        throw new HttpRequestException("Muwaqqit API returned an empty or invalid JSON payload.");
+                    }
+
+                    return deserialized;
+                }
+
+                if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                {
+                    var retryDelay = response.Headers.RetryAfter?.Delta ?? DefaultRetryDelay;
+
+                    if (attempt == MaxApiRetries)
+                    {
+                        break;
+                    }
+
+                    _logger.LogWarning("Rate limit hit. Retrying in {RetryDelaySeconds} seconds (attempt {Attempt}/{MaxAttempts}).", retryDelay.TotalSeconds, attempt, MaxApiRetries);
+                    await Task.Delay(retryDelay);
+                    continue;
+                }
+
+                if ((int)response.StatusCode >= 500 && attempt < MaxApiRetries)
+                {
+                    var retryDelay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+                    _logger.LogWarning("Transient server error {StatusCode}. Retrying in {RetryDelaySeconds} seconds (attempt {Attempt}/{MaxAttempts}).", response.StatusCode, retryDelay.TotalSeconds, attempt, MaxApiRetries);
+                    await Task.Delay(retryDelay);
+                    continue;
+                }
+
+                response.EnsureSuccessStatusCode();
             }
 
-            response.EnsureSuccessStatusCode();
-            var responseContent = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<MuwaqqitResponse>(responseContent);
+            throw new HttpRequestException($"Failed to fetch prayer data from API after {MaxApiRetries} attempts.");
         }
 
         private async Task<CityPrayerTimes> ProcessAndStoreApiData(CityPrayerTimes cityPrayerTimes, MuwaqqitResponse muwaqqitResponse, string city)

--- a/Web/Controllers/DiagnosticsController.cs
+++ b/Web/Controllers/DiagnosticsController.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Web.Controllers
+{
+    [ApiController]
+    [Route("diag")]
+    public class DiagnosticsController : ControllerBase
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<DiagnosticsController> _logger;
+
+        public DiagnosticsController(IHttpClientFactory httpClientFactory, ILogger<DiagnosticsController> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        [HttpGet("muwaqqit")]
+        public async Task<IActionResult> Muwaqqit([FromQuery] bool forceHttp11 = false)
+        {
+            const string url = "https://www.muwaqqit.com/api.json?lt=55.6759142&ln=12.5691285&d=2026-04-29&tz=Europe%2FCopenhagen&fa=-18.0&ea=-17.0&fea=0&rsa=0";
+            var client = _httpClientFactory.CreateClient();
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+                if (forceHttp11)
+                {
+                    request.Version = HttpVersion.Version11;
+                    request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                }
+
+                using var response = await client.SendAsync(request);
+                var bodyPreview = await response.Content.ReadAsStringAsync();
+
+                return Ok(new
+                {
+                    success = response.IsSuccessStatusCode,
+                    statusCode = (int)response.StatusCode,
+                    responseVersion = response.Version.ToString(),
+                    requestVersion = request.Version.ToString(),
+                    forceHttp11,
+                    headers = response.Headers.ToDictionary(h => h.Key, h => string.Join(",", h.Value)),
+                    bodyPreview = bodyPreview.Length > 500 ? bodyPreview.Substring(0, 500) : bodyPreview
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Muwaqqit diagnostic call failed. forceHttp11={ForceHttp11}", forceHttp11);
+
+                return StatusCode(500, new
+                {
+                    success = false,
+                    exceptionType = ex.GetType().FullName,
+                    exceptionMessage = ex.Message,
+                    innerExceptionType = ex.InnerException?.GetType().FullName,
+                    innerExceptionMessage = ex.InnerException?.Message,
+                    secondInnerExceptionType = ex.InnerException?.InnerException?.GetType().FullName,
+                    secondInnerExceptionMessage = ex.InnerException?.InnerException?.Message,
+                    forceHttp11
+                });
+            }
+        }
+    }
+}

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
+using System.Runtime.InteropServices;
 using System;
 
 namespace Web
@@ -20,6 +21,11 @@ namespace Web
             try
             {
                 Log.Information("Starting web host");
+                Log.Information("Runtime diagnostics: Framework={Framework}, EnvironmentVersion={EnvironmentVersion}, OS={OS}, Architecture={Architecture}",
+                    RuntimeInformation.FrameworkDescription,
+                    Environment.Version,
+                    RuntimeInformation.OSDescription,
+                    RuntimeInformation.OSArchitecture);
                 CreateHostBuilder(args).Build().Run();
             }
             catch (Exception ex)

--- a/Web/Services/MonthlyPrayerTimesRefreshService.cs
+++ b/Web/Services/MonthlyPrayerTimesRefreshService.cs
@@ -1,0 +1,92 @@
+using Application.Interfaces;
+using Domain.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+namespace Web.Services
+{
+    public class MonthlyPrayerTimesRefreshService : BackgroundService
+    {
+        private static readonly string[] SupportedCities = new[] { "cph", "odense", "aarhus", "aalborg" };
+
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<MonthlyPrayerTimesRefreshService> _logger;
+
+        public MonthlyPrayerTimesRefreshService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<MonthlyPrayerTimesRefreshService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var denmarkTimeZone = GetDenmarkTimeZone();
+
+            await RefreshIfNeededAsync(denmarkTimeZone, stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var delay = GetDelayUntilNextMidnight(denmarkTimeZone);
+                _logger.LogInformation("Monthly refresh worker sleeping for {Delay} until next Denmark midnight.", delay);
+                await Task.Delay(delay, stoppingToken);
+                await RefreshIfNeededAsync(denmarkTimeZone, stoppingToken);
+            }
+        }
+
+        private async Task RefreshIfNeededAsync(TimeZoneInfo denmarkTimeZone, CancellationToken cancellationToken)
+        {
+            var nowInDenmark = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, denmarkTimeZone);
+            var firstOfMonth = new DateTime(nowInDenmark.Year, nowInDenmark.Month, 1);
+
+            using var scope = _scopeFactory.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<ICityPrayerTimesRepository>();
+            var prayerTimeService = scope.ServiceProvider.GetRequiredService<IPrayerTimeService>();
+
+            var allRows = await repository.GetAllAsync();
+            var hasCurrentMonthData = allRows
+                .SelectMany(c => c.PrayerTimes)
+                .Any(p => p.Date.Year == firstOfMonth.Year && p.Date.Month == firstOfMonth.Month);
+
+            if (hasCurrentMonthData)
+            {
+                _logger.LogInformation("Monthly refresh skipped. Data for {Month}/{Year} already exists.", firstOfMonth.Month, firstOfMonth.Year);
+                return;
+            }
+
+            _logger.LogInformation("Refreshing prayer calendar data for {Month}/{Year}.", firstOfMonth.Month, firstOfMonth.Year);
+            await repository.TruncateTablesAsync();
+
+            foreach (var city in SupportedCities)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await prayerTimeService.FetchAndCachePrayerTimesAsync(city);
+            }
+
+            _logger.LogInformation("Monthly prayer calendar refresh complete for {Month}/{Year}.", firstOfMonth.Month, firstOfMonth.Year);
+        }
+
+        private static TimeSpan GetDelayUntilNextMidnight(TimeZoneInfo denmarkTimeZone)
+        {
+            var nowInDenmark = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, denmarkTimeZone);
+            var nextMidnightInDenmark = nowInDenmark.Date.AddDays(1);
+            return nextMidnightInDenmark - nowInDenmark;
+        }
+
+        private static TimeZoneInfo GetDenmarkTimeZone()
+        {
+            var timeZoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? "Romance Standard Time"
+                : "Europe/Copenhagen";
+
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+    }
+}

--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using Web.Mapping;
+using Web.Services;
 
 namespace Web
 {
@@ -51,6 +52,7 @@ namespace Web
             services.AddHttpClient<IPrayerTimeService, PrayerTimeService>();
             services.AddAutoMapper(typeof(MappingProfile));
             services.AddAutoMapper(typeof(DTOToviewModelMappingProfile));
+            services.AddHostedService<MonthlyPrayerTimesRefreshService>();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)


### PR DESCRIPTION
### Motivation

- Improve resilience against Muwaqqit API rate limits and transient errors by adding retry/backoff logic and detection of body-only 429 responses. 
- Provide operational diagnostics to inspect live Muwaqqit responses and HTTP version behavior. 
- Automate monthly refresh of prayer calendars and ensure safe table truncation across platforms. 

### Description

- Implemented retry and backoff logic in `PrayerTimeService.GetApiPrayerData` with `MaxApiRetries`, `DefaultRetryDelay`, handling of body-only "429" responses, `Retry-After` headers, and exponential backoff for 5xx responses, and throw a descriptive `HttpRequestException` after exhausting retries. 
- Modified `CityPrayerTimesRepository.TruncateTablesAsync` to use a transaction and `DELETE FROM` instead of `TRUNCATE` with toggling foreign key checks, and commit the transaction to ensure cross-platform safety. 
- Added `DiagnosticsController` (`/diag/muwaqqit`) that returns Muwaqqit response metadata and an optional `forceHttp11` flag for request diagnostics. 
- Added `MonthlyPrayerTimesRefreshService` background worker that runs at Denmark midnight, checks if current month data exists, truncates tables, and refreshes prayer times for supported cities (`cph`, `odense`, `aarhus`, `aalborg`). 
- Logged runtime diagnostics in `Program.Main` using `RuntimeInformation`, and registered the new hosted service in `Startup.ConfigureServices`. 

### Testing

- Executed the repository's automated test suite (unit and integration tests) after changes and all tests passed. 
- Verified that background service and hosted registration compile in the web project via the standard build/CI pipeline which succeeded. 
- No new automated tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25bcd02c88328bccc51e92fb80529)