### PR TITLE
Add URL fallbacks and TLS-handshake retry for Muwaqqit API calls

### DIFF
--- a/Infrastructure/Services/PrayerTimeService.cs
+++ b/Infrastructure/Services/PrayerTimeService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Threading;
 
 namespace Infrastructure.Services
@@ -138,11 +139,33 @@ namespace Infrastructure.Services
 
         private async Task<MuwaqqitResponse> GetApiPrayerData(string url)
         {
-            for (var attempt = 1; attempt <= MaxApiRetries; attempt++)
-            {
-                HttpResponseMessage response = await _httpClient.GetAsync(url);
+            var candidateUrls = GetCandidateApiUrls(url);
 
-                _logger.LogInformation("Received HTTP status {StatusCode} for URL {Url} on attempt {Attempt}/{MaxAttempts}", response.StatusCode, url, attempt, MaxApiRetries);
+            foreach (var candidateUrl in candidateUrls)
+            {
+                for (var attempt = 1; attempt <= MaxApiRetries; attempt++)
+                {
+                    HttpResponseMessage response;
+
+                    try
+                    {
+                        response = await _httpClient.GetAsync(candidateUrl);
+                    }
+                    catch (HttpRequestException ex) when (IsTlsHandshakeFailure(ex))
+                    {
+                        _logger.LogWarning(ex, "TLS handshake failure while requesting {Url} (attempt {Attempt}/{MaxAttempts}).", candidateUrl, attempt, MaxApiRetries);
+
+                        if (attempt == MaxApiRetries)
+                        {
+                            break;
+                        }
+
+                        var retryDelay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+                        await Task.Delay(retryDelay);
+                        continue;
+                    }
+
+                    _logger.LogInformation("Received HTTP status {StatusCode} for URL {Url} on attempt {Attempt}/{MaxAttempts}", response.StatusCode, candidateUrl, attempt, MaxApiRetries);
 
                 if (response.IsSuccessStatusCode)
                 {
@@ -192,9 +215,33 @@ namespace Infrastructure.Services
                 }
 
                 response.EnsureSuccessStatusCode();
+                }
             }
 
-            throw new HttpRequestException($"Failed to fetch prayer data from API after {MaxApiRetries} attempts.");
+            throw new HttpRequestException($"Failed to fetch prayer data from API after trying {candidateUrls.Count} URL variant(s) with {MaxApiRetries} attempts each.");
+        }
+
+        private static List<string> GetCandidateApiUrls(string url)
+        {
+            var candidates = new List<string> { url };
+
+            if (url.Contains("www.muwaqqit.com", StringComparison.OrdinalIgnoreCase))
+            {
+                candidates.Add(url.Replace("www.muwaqqit.com", "api.muwaqqit.com", StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                candidates.Add($"http://{url["https://".Length..]}");
+            }
+
+            return candidates.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        }
+
+        private static bool IsTlsHandshakeFailure(HttpRequestException ex)
+        {
+            return ex.InnerException is AuthenticationException
+                || ex.InnerException?.InnerException is AuthenticationException;
         }
 
         private async Task<CityPrayerTimes> ProcessAndStoreApiData(CityPrayerTimes cityPrayerTimes, MuwaqqitResponse muwaqqitResponse, string city)


### PR DESCRIPTION
### Motivation
- Prevent hard failures when the Muwaqqit endpoint fails TLS negotiation by adding resilient retry behavior and alternate endpoint/protocol variants. 
- Improve observability by logging TLS handshake failures and making final error messages clearer about the attempts made.

### Description
- Added `using System.Security.Authentication;` and a new `IsTlsHandshakeFailure(HttpRequestException)` helper to detect TLS handshake errors. 
- Reworked `GetApiPrayerData` to build a list of candidate URLs and iterate them, retrying each candidate up to `MaxApiRetries` with exponential backoff on transient TLS handshake failures. 
- Added `GetCandidateApiUrls(string)` to generate fallbacks (original URL, `www.muwaqqit.com` -> `api.muwaqqit.com`, and HTTPS -> HTTP). 
- Added warning logs for handshake failures and updated the terminal `HttpRequestException` to report how many URL variants were tried.

### Testing
- Attempted to build the solution with `dotnet build PrayerTimes.sln`, but the build could not be run in this environment because the .NET SDK is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f660d634ac83289191663d12a5820e)